### PR TITLE
Convert to Claude Code plugin: workflows → skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,11 +7,6 @@
     "url": "https://github.com/nabeelhyatt"
   },
   "homepage": "https://github.com/nabeelhyatt/coworkpowers",
-  "tags": ["knowledge-work", "productivity", "compound-learning", "decision-making", "research", "planning"],
-  "workflows": [
-    "coworkflows:research",
-    "coworkflows:work",
-    "coworkflows:review",
-    "coworkflows:compound"
-  ]
+  "license": "MIT",
+  "keywords": ["knowledge-work", "productivity", "compound-learning", "decision-making", "research", "planning"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Thumbs.db
 # Cache
 .cache/
 *.cache
+
+# User-specific context and learnings
+.context/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # CoworkPowers: Knowledge Work Superpowers
 
-You have access to CoworkPowers, a system that makes knowledge work compound over time. Use the four core workflows to research, execute, review, and capture learnings.
+You have access to CoworkPowers, a system that makes knowledge work compound over time. Use the four core skills to research, execute, review, and capture learnings.
 
-## Core Workflows
+## Core Skills
 
-Use these workflows for any significant knowledge work:
+Use these skills for any significant knowledge work:
 
-### `/coworkflows:research`
+### `/coworkpowers:research`
 Research and plan thoroughly before execution. Use when starting:
 - Important communications (board updates, difficult conversations)
 - Strategic decisions (build vs. buy, pricing, hiring)
@@ -22,12 +22,12 @@ Research and plan thoroughly before execution. Use when starting:
 
 **Example:**
 ```
-/coworkflows:research
+/coworkpowers:research
 
 "I need to prepare for next week's board meeting"
 ```
 
-### `/coworkflows:work`
+### `/coworkpowers:work`
 Execute a plan systematically with specialized agents. Use after research phase.
 
 **Available agents:**
@@ -40,12 +40,12 @@ Execute a plan systematically with specialized agents. Use after research phase.
 
 **Example:**
 ```
-/coworkflows:work
+/coworkpowers:work
 
 Follow the board prep plan using meeting-orchestrator
 ```
 
-### `/coworkflows:review`
+### `/coworkpowers:review`
 Multi-agent quality review from specialized perspectives. Use after drafting/execution.
 
 **Review agents run in parallel:**
@@ -55,12 +55,12 @@ Multi-agent quality review from specialized perspectives. Use after drafting/exe
 
 **Example:**
 ```
-/coworkflows:review
+/coworkpowers:review
 
 Review the board presentation draft
 ```
 
-### `/coworkflows:compound`
+### `/coworkpowers:compound`
 Extract patterns, templates, and preferences to make next time easier. Use after completing work.
 
 **What it captures:**
@@ -71,7 +71,7 @@ Extract patterns, templates, and preferences to make next time easier. Use after
 
 **Example:**
 ```
-/coworkflows:compound
+/coworkpowers:compound
 
 That board meeting went really well, let's capture what worked
 ```
@@ -79,7 +79,7 @@ That board meeting went really well, let's capture what worked
 ## Key Principles
 
 ### Ask First, Research Second
-The research workflow asks clarifying questions BEFORE launching expensive parallel research. This prevents wasted work on the wrong problem.
+The research skill asks clarifying questions BEFORE launching expensive parallel research. This prevents wasted work on the wrong problem.
 
 ### Compound Everything Worth Repeating
 Every completed task should feed insights back into the system. The first board update takes 4 hours. The second takes 1 hour. That's compounding.
@@ -90,11 +90,11 @@ Every completed task should feed insights back into the system. The first board 
 - **High stakes** (board, strategy, sensitive): Full research + multi-agent review + compound
 
 ### Be Honest About Failures
-When something doesn't go well, run `/coworkflows:compound` immediately. Failure insights are the most valuable compounding opportunities.
+When something doesn't go well, run `/coworkpowers:compound` immediately. Failure insights are the most valuable compounding opportunities.
 
 ## Hard Gates & Red Flags
 
-For high-stakes work, the research workflow will ask these questions BEFORE proceeding:
+For high-stakes work, the research skill will ask these questions BEFORE proceeding:
 1. Who is the audience/stakeholder?
 2. What does success look like?
 3. What constraints exist (political, budget, timing)?
@@ -126,19 +126,19 @@ Each insight is a discrete, self-contained markdown file with YAML frontmatter f
 User: "I need to tell the team about layoffs"
 
 # Research phase
-/coworkflows:research
+/coworkpowers:research
 # Asks: Stakes? Audience? Timeline? Past attempts?
 # Searches: Past sensitive communications
 # Gathers: Company context, team morale
 # Produces: Structured communication plan
 
 # Work phase
-/coworkflows:work
+/coworkpowers:work
 # Uses diplomat + executive-writer agents
 # Drafts sensitive communication
 
 # Review phase
-/coworkflows:review
+/coworkpowers:review
 # 5 agents review in parallel
 # Flags: Tone issue, missing support resources section
 
@@ -146,7 +146,7 @@ User: "I need to tell the team about layoffs"
 # ...
 
 # Compound phase
-/coworkflows:compound
+/coworkpowers:compound
 # Captures: Pattern for sensitive communications
 # Documents: "Always include support resources"
 # Creates: Template for layoff communications
@@ -162,4 +162,4 @@ The second difficult communication takes half the time and has twice the quality
 
 ---
 
-**That's it.** Four workflows. Each task makes the next one easier. Knowledge compounds.
+**That's it.** Four skills. Each task makes the next one easier. Knowledge compounds.

--- a/README.md
+++ b/README.md
@@ -2,44 +2,44 @@
 
 **Knowledge work superpowers that compound over time.**
 
-CoworkPowers gives Claude systematic capabilities for tackling knowledge work—drafting communications, making decisions, preparing for meetings, and more. Each completed task feeds insights back into the system, making the next similar task faster and better.
+CoworkPowers is a Claude Code plugin that gives Claude systematic capabilities for tackling knowledge work -- drafting communications, making decisions, preparing for meetings, and more. Each completed task feeds insights back into the system, making the next similar task faster and better.
 
 ## The Compound Loop
 
-1. **Research** (`/coworkflows:research`) - Thoroughly research the task, search past learnings, gather context
-2. **Work** (`/coworkflows:work`) - Execute the plan with specialized agents
-3. **Review** (`/coworkflows:review`) - Multi-agent quality review from multiple perspectives
-4. **Compound** (`/coworkflows:compound`) - Extract patterns, templates, and preferences for next time
+1. **Research** (`/coworkpowers:research`) - Thoroughly research the task, search past learnings, gather context
+2. **Work** (`/coworkpowers:work`) - Execute the plan with specialized agents
+3. **Review** (`/coworkpowers:review`) - Multi-agent quality review from multiple perspectives
+4. **Compound** (`/coworkpowers:compound`) - Extract patterns, templates, and preferences for next time
 
 ## Key Features
 
-### 🔄 Compounding Knowledge
+### Compounding Knowledge
 - Automatically captures patterns, templates, and preferences from completed work
 - Searches past learnings before starting new tasks
-- Gets smarter with each use—first board update takes 4 hours, next takes 1 hour
+- Gets smarter with each use -- first board update takes 4 hours, next takes 1 hour
 
-### 🎯 Specialized Agents
+### Specialized Agents
 - **decision-architect**: Structure decisions with 40+ frameworks (SPADE, SWOT, Cynefin, Pre-Mortem)
 - **context-gatherer**: Research comprehensive background before acting
 - **executive-writer**: Draft clear, concise business communications
 - **coach**: CEO-level coaching for leadership challenges
 - Plus 10+ more specialized agents
 
-### ✅ Hard Gates & Red Flags
+### Hard Gates & Red Flags
 - Asks clarifying questions before launching expensive research
 - Catches high-stakes work early (board communications, sensitive topics)
-- Verification-before-claims patterns from superpowers
+- Verification-before-claims patterns
 
-### 📚 Dual-Environment Design
-- Works in Claude Code (file-based retrieval with grep/glob)
-- Designed for Camp channels (automatic compaction + relevance filtering)
+### Insight Storage
 - Insights stored as discrete markdown files with YAML frontmatter
+- Fast retrieval via grep/glob during the research phase
+- Searchable index for category, type, and tag-based lookup
 
 ## Quick Start
 
 ### 1. Research Phase
 ```
-/coworkflows:research
+/coworkpowers:research
 
 "I need to draft an email to the board about Q2 results"
 ```
@@ -52,14 +52,14 @@ Claude will:
 
 ### 2. Work Phase
 ```
-/coworkflows:work
+/coworkpowers:work
 
 Follow the plan from research phase
 ```
 
 ### 3. Review Phase
 ```
-/coworkflows:review
+/coworkpowers:review
 
 Review the draft email
 ```
@@ -71,7 +71,7 @@ Multiple specialized reviewers check in parallel:
 
 ### 4. Compound Phase
 ```
-/coworkflows:compound
+/coworkpowers:compound
 
 The board loved it! Let's capture what worked
 ```
@@ -80,26 +80,29 @@ Extracts patterns, creates templates, documents preferences for next time.
 
 ## Installation
 
-### Option 1: Claude Code Plugin (Recommended)
+### Option 1: Test Locally (Development)
 ```bash
-# Clone to Claude plugins directory
-cd ~/.claude/plugins/repos/
+# Clone the repository
 git clone https://github.com/nabeelhyatt/coworkpowers.git
 
-# Enable in Claude Code settings
+# Run Claude Code with the plugin loaded
+claude --plugin-dir ./coworkpowers
 ```
 
-### Option 2: Manual Installation
-Copy the `workflows/` and `agents/` directories to your Claude skills folder.
+### Option 2: Install from Marketplace
+```bash
+# Once published to a marketplace
+/plugin install coworkpowers@marketplace-name
+```
 
-## Workflows
+## Skills
 
 | Command | Purpose | When to Use |
 |---------|---------|-------------|
-| `/coworkflows:research` | Research and plan thoroughly | Starting any significant work |
-| `/coworkflows:work` | Execute the plan systematically | After research phase |
-| `/coworkflows:review` | Multi-agent quality review | After drafting/execution |
-| `/coworkflows:compound` | Extract learnings for next time | After completing work |
+| `/coworkpowers:research` | Research and plan thoroughly | Starting any significant work |
+| `/coworkpowers:work` | Execute the plan systematically | After research phase |
+| `/coworkpowers:review` | Multi-agent quality review | After drafting/execution |
+| `/coworkpowers:compound` | Extract learnings for next time | After completing work |
 
 ## Specialized Agents
 
@@ -124,11 +127,27 @@ Copy the `workflows/` and `agents/` directories to your Claude skills folder.
 - **sensitivity-scanner** - Political considerations and risks
 - **actionability-validator** - Clear next steps
 
+## Plugin Structure
+
+```
+coworkpowers/
+  .claude-plugin/
+    plugin.json           # Plugin manifest
+  skills/
+    research/SKILL.md     # Research & planning skill
+    work/SKILL.md         # Execution skill
+    review/SKILL.md       # Multi-agent review skill
+    compound/SKILL.md     # Knowledge compounding skill
+  agents/                 # 20+ specialized agent definitions
+  CLAUDE.md               # Project instructions
+  README.md
+```
+
 ## Example: Board Communication
 
 ```bash
 # 1. Research
-/coworkflows:research "Draft Q2 board update"
+/coworkpowers:research "Draft Q2 board update"
 
 # Claude asks clarifying questions:
 # - What's the most important message? (hypothesis: growth trajectory)
@@ -140,16 +159,16 @@ Copy the `workflows/` and `agents/` directories to your Claude skills folder.
 # Produces structured plan
 
 # 2. Work
-/coworkflows:work
+/coworkpowers:work
 # Follows plan, drafts update using executive-writer agent
 
 # 3. Review
-/coworkflows:review
+/coworkpowers:review
 # 5 specialized reviewers check in parallel
 # Identifies: tone too casual for board, missing risk section
 
 # 4. Compound
-/coworkflows:compound "Board loved it"
+/coworkpowers:compound "Board loved it"
 # Captures: "Board prefers bullet points over prose"
 # Creates: Board update template
 # Documents: Success pattern for future use
@@ -216,15 +235,11 @@ takeaway: One-sentence key learning
   ...
 ```
 
-### Search & Retrieval
-- **Claude Code**: Grep/glob search across category directories and INDEX.md
-- **Camp**: Automatic compaction into channel knowledge base + relevance filtering
-
 ## Contributing
 
 Contributions welcome! This plugin is designed to be extended:
 - Add new specialized agents
-- Create new workflow phases
+- Create new skill phases
 - Enhance existing agents with new frameworks
 
 ## License
@@ -238,4 +253,4 @@ Inspired by:
 - [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin) - Compounding knowledge philosophy
 - Kieran Klaassen's work on compound systems
 
-Built with ❤️ for knowledge workers who want their AI to get smarter over time.
+Built for knowledge workers who want their AI to get smarter over time.

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: coworkflows:compound
-description: "Extract and store learnings from completed knowledge work to make the next task easier. Use this after completing any significant piece of work to capture patterns, create templates, and update preferences.\n\nExamples:\n- <example>\n  Context: The user just finished a successful board presentation.\n  user: \"That board meeting went really well, let's capture what worked\"\n  assistant: \"I'll extract the patterns that worked - the structure, the framing, the level of detail - and create a reusable template for future board presentations.\"\n  <commentary>\n  Success patterns should be captured immediately while context is fresh.\n  </commentary>\n  </example>\n- <example>\n  Context: A communication didn't land well.\n  user: \"That announcement didn't go over well with the team\"\n  assistant: \"I'll analyze what went wrong - the framing, the timing, the channel - and document lessons for future sensitive communications.\"\n  <commentary>\n  Failures are the most valuable compounding opportunities if analyzed honestly.\n  </commentary>\n  </example>"
-model: inherit
+name: compound
+description: "Extract and store learnings from completed knowledge work to make the next task easier. Use after completing any significant piece of work to capture patterns, create templates, and update preferences. Triggers on requests like 'that went well, let's capture what worked', 'what did we learn', 'that didn't go well', or after completing high-stakes work."
+disable-model-invocation: true
 ---
 
-# Camp Compound: Knowledge Compounding Workflow
+# Compound: Knowledge Compounding Workflow
 
 You are orchestrating the **Compound phase** of the Compound Knowledge Work loop. Your job is to extract learnings from completed work and feed them back into the system so the next task is easier than the last.
 
@@ -13,14 +13,6 @@ You are orchestrating the **Compound phase** of the Compound Knowledge Work loop
 ## Philosophy
 
 Each documented pattern, template, and preference makes the next similar task faster and better. First attempt at a board update takes 4 hours of planning and drafting. Document the approach, and the next one takes 1 hour. That's compounding.
-
-## Design Note: Dual-Environment Architecture
-
-This workflow produces insights as **local markdown files** — the universal format that works in any Claude Code environment. These same insights are designed to be **synced as channel insights in Camp**, where they get automatically compacted and relevance-filtered. The file format is intentionally structured so each insight is self-contained and can become a discrete channel insight.
-
-- **Claude Code**: Insights are stored as files, retrieved by grep/glob during the Research phase
-- **Camp**: Insights sync to channel knowledge bases, retrieved by LLM compaction + relevance filtering
-- **The format serves both**: YAML frontmatter for structured search, self-contained body for LLM consumption
 
 ## Process
 
@@ -53,7 +45,7 @@ Launch these research agents in parallel:
 
 ### Phase 2: Produce Discrete Insights
 
-From the analysis, produce **individual, self-contained insights**. Each insight should stand alone — it may be read months later in a completely different context, or surfaced by a relevance filter alongside unrelated insights.
+From the analysis, produce **individual, self-contained insights**. Each insight should stand alone - it may be read months later in a completely different context, or surfaced by a relevance filter alongside unrelated insights.
 
 Every task should produce at least one insight. Most will produce 2-5. Each insight gets its own type:
 
@@ -75,7 +67,7 @@ category: [communication | decision | analysis | meeting | coaching | operations
 task: [Brief description of the original task]
 outcome: [success | partial | failure]
 tags: [comma-separated: stakeholder names, frameworks, topics, projects]
-takeaway: [One sentence — the key thing to remember. This is what gets searched.]
+takeaway: [One sentence - the key thing to remember. This is what gets searched.]
 ---
 
 # [Descriptive Title]
@@ -84,7 +76,7 @@ takeaway: [One sentence — the key thing to remember. This is what gets searche
 [2-3 sentences: What task this came from, what the situation was]
 
 ## The Learning
-[The actual insight, pattern, template, preference, or failure analysis. Self-contained — a reader should understand this without seeing anything else.]
+[The actual insight, pattern, template, preference, or failure analysis. Self-contained - a reader should understand this without seeing anything else.]
 
 ## When to Apply
 [Specific situations where this insight is relevant. Be concrete.]
@@ -93,7 +85,7 @@ takeaway: [One sentence — the key thing to remember. This is what gets searche
 [References to related insights by filename, if any]
 ```
 
-**Keep each insight focused.** One pattern per file, one preference per file, one template per file. If a task yielded a good pattern AND a template AND a preference, that's three separate insight files. This granularity is what makes retrieval work — both for grep (Claude Code) and for relevance filtering (Camp).
+**Keep each insight focused.** One pattern per file, one preference per file, one template per file. If a task yielded a good pattern AND a template AND a preference, that's three separate insight files. This granularity is what makes retrieval work.
 
 ### Phase 3: Store and Index
 
@@ -103,7 +95,7 @@ Insights must be stored so the **Research phase can find them quickly** by categ
    - Path: `.context/learnings/[category]/YYYY-MM-DD-[type]-[brief-description].md`
    - Categories: `communication/`, `decision/`, `analysis/`, `meeting/`, `coaching/`, `operations/`
    - Create the directory if it doesn't exist
-   - Use descriptive filenames that are greppable (e.g., `2026-02-12-pattern-premoterm-board-prep.md`)
+   - Use descriptive filenames that are greppable (e.g., `2026-02-12-pattern-premortem-board-prep.md`)
 
 2. **Update the learnings index** at `.context/learnings/INDEX.md`:
    - Add a row per insight with all searchable fields
@@ -116,7 +108,6 @@ Insights must be stored so the **Research phase can find them quickly** by categ
    | Date | Type | Category | Title | Outcome | Tags | Takeaway | File |
    |------|------|----------|-------|---------|------|----------|------|
    | 2026-02-12 | pattern | decision | Pre-mortem for board decisions | success | board, pre-mortem, risk | Pre-mortem surfaces risks the team glosses over in optimistic planning | decision/2026-02-12-pattern-premortem-board.md |
-   | 2026-02-12 | preference | communication | Executive summary format | success | email, executives, formatting | Prefers bullet points over prose in executive summaries | communication/2026-02-12-preference-exec-summary-format.md |
    ```
 
    The Research phase searches this index by: type, category, tags, and full-text grep across the Takeaway column. **Every field matters for retrieval.**
@@ -150,22 +141,18 @@ Present these suggestions to the user for approval.
 - Prevention > cure
 
 ### Keep It Retrievable
-- The Research phase searches learnings by category directory, INDEX.md table, and grep — structure for all three
-- In Camp, these same insights get compacted and relevance-filtered — structure for LLM readability too
 - Descriptive filenames, deliberate tags, and one-sentence takeaways are what make retrieval work
 - Cross-reference related insights in the "Related" section
-- The index is sacred — keep it updated
+- The index is sacred - keep it updated
 
 ### One Insight Per File
 - Granular insights are findable; monolithic documents are not
 - A pattern, a template, and a preference from the same task are three separate files
 - Each file should be self-contained: readable without context
-- This granularity enables both grep retrieval and Camp's relevance filtering
 
 ### Preferences Are Insights
-- Style, tone, and detail preferences are channel/project-scoped, not universal
+- Style, tone, and detail preferences are project-scoped, not universal
 - Store them as `preference` type insights alongside patterns and templates
-- They flow through the same system: local files for Claude Code, channel insights for Camp
 
 ### Templates Compound Fastest
 - A good template saves the most time on repeat tasks
@@ -176,7 +163,7 @@ Present these suggestions to the user for approval.
 
 | Situation | Compound? | Focus On |
 |-----------|-----------|----------|
-| Completed high-stakes work | Always | Full analysis — patterns, templates, preferences |
+| Completed high-stakes work | Always | Full analysis - patterns, templates, preferences |
 | Work received positive feedback | Yes | What worked, template creation |
 | Work received negative feedback | Absolutely | Failure insights, prevention |
 | Routine work done well | Sometimes | Efficiency patterns |
@@ -191,4 +178,4 @@ Present these suggestions to the user for approval.
 - Not indexing or tagging (unfindable knowledge is useless)
 - Putting multiple learnings in one file (breaks retrieval granularity)
 - Over-documenting routine work
-- Forgetting to check existing learnings before starting new work (the Research phase does this — but only if you stored them properly here)
+- Forgetting to check existing learnings before starting new work

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,10 +1,9 @@
 ---
-name: coworkflows:research
-description: "Research and plan a knowledge work task thoroughly before execution. Use this when starting any significant piece of work - from drafting important communications to making strategic decisions to preparing for meetings.\n\nExamples:\n- <example>\n  Context: The user needs to prepare for a board meeting.\n  user: \"I need to prepare for next week's board meeting\"\n  assistant: \"I'll create a comprehensive preparation plan - gathering context, mapping stakeholder concerns, researching precedents, and building your agenda.\"\n  <commentary>\n  Board prep is high-stakes knowledge work that benefits from structured planning.\n  </commentary>\n  </example>\n- <example>\n  Context: The user needs to draft a difficult communication.\n  user: \"I need to tell the team about layoffs\"\n  assistant: \"I'll plan this carefully - understanding the context, mapping stakeholder reactions, researching best practices, and structuring the communication approach.\"\n  <commentary>\n  Sensitive communications require thorough planning before any drafting begins.\n  </commentary>\n  </example>"
-model: inherit
+name: research
+description: "Research and plan a knowledge work task thoroughly before execution. Use when starting any significant piece of work - drafting important communications, making strategic decisions, preparing for meetings, or tackling analysis projects. Triggers on requests like 'help me prepare for', 'I need to draft', 'plan out', or any high-stakes knowledge work."
 ---
 
-# Camp Research: Knowledge Work Research Workflow
+# Research: Knowledge Work Research Workflow
 
 You are orchestrating the **Research phase** of the Compound Knowledge Work loop. Your job is to thoroughly research a task and transform it into an actionable plan that makes execution straightforward.
 
@@ -24,9 +23,9 @@ You are orchestrating the **Research phase** of the Compound Knowledge Work loop
    - Operations (process design, project planning, documentation)
 
 3. **Determine stakes and complexity:**
-   - **Low stakes**: Internal notes, routine updates → lighter planning
-   - **Medium stakes**: Team communications, standard decisions → moderate planning
-   - **High stakes**: Board communications, strategic decisions, sensitive topics → full planning
+   - **Low stakes**: Internal notes, routine updates -> lighter planning
+   - **Medium stakes**: Team communications, standard decisions -> moderate planning
+   - **High stakes**: Board communications, strategic decisions, sensitive topics -> full planning
 
 ### Phase 1.5: Ask Clarifying Questions
 
@@ -68,13 +67,11 @@ Before launching research, identify gaps and ask the user clarifying questions. 
 Before any new research, check what we already know. This is where compounding pays off.
 
 **In Claude Code** (file-based retrieval):
-1. **Check the learnings index** at `.context/learnings/INDEX.md` — scan for matching category, type, and tags.
+1. **Check the learnings index** at `.context/learnings/INDEX.md` - scan for matching category, type, and tags.
 2. **Search by category**: Grep `.context/learnings/[category]/` for the relevant work type (e.g., `communication/`, `decision/`, `meeting/`).
 3. **Search by type**: Look specifically for `pattern` and `template` insights that match the current task.
 4. **Search by keywords**: Grep across all learnings for topic-specific terms (stakeholder names, project names, framework names).
-5. **Search for preferences**: Grep for `type: preference` insights in the relevant category — these capture style, tone, and detail preferences from previous work.
-
-**In Camp** (channel context): Relevant learnings will also be surfaced automatically via the channel's knowledge base and relevance filtering. The explicit search above is belt-and-suspenders — it catches things the automatic system might miss and works in any environment.
+5. **Search for preferences**: Grep for `type: preference` insights in the relevant category - these capture style, tone, and detail preferences from previous work.
 
 If past learnings exist, incorporate them into the plan:
 - **Reuse patterns** (type: `pattern`) that worked before

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,10 +1,9 @@
 ---
-name: coworkflows:review
-description: "Run parallel multi-agent review on completed knowledge work. Use this after the Work phase to evaluate output quality from multiple specialized perspectives before finalizing.\n\nExamples:\n- <example>\n  Context: The user has drafted an important email.\n  user: \"Review this email before I send it\"\n  assistant: \"I'll run parallel reviews for clarity, tone, strategic alignment, completeness, and sensitivity - then synthesize findings into prioritized fixes.\"\n  <commentary>\n  Important communications benefit from multi-perspective review to catch issues a single reviewer would miss.\n  </commentary>\n  </example>\n- <example>\n  Context: The user has a decision memo ready.\n  user: \"Stress-test this recommendation\"\n  assistant: \"I'll run the devil's advocate, risk assessor, completeness auditor, and strategic alignment checker in parallel to find weaknesses.\"\n  <commentary>\n  Decision memos need adversarial review to ensure robustness before presentation.\n  </commentary>\n  </example>"
-model: inherit
+name: review
+description: "Run parallel multi-agent review on completed knowledge work. Use after the work phase to evaluate output quality from multiple specialized perspectives before finalizing. Triggers on requests like 'review this', 'check this before I send it', 'stress-test this recommendation', or when quality assurance is needed on a deliverable."
 ---
 
-# Camp Review: Multi-Agent Knowledge Work Review
+# Review: Multi-Agent Knowledge Work Review
 
 You are orchestrating the **Review phase** of the Compound Knowledge Work loop. Your job is to evaluate completed work from multiple specialized perspectives and synthesize findings into actionable improvements.
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: coworkflows:work
-description: "Execute a knowledge work plan efficiently while maintaining quality. Use this after planning is complete to systematically work through the plan, using the right agents for each step.\n\nExamples:\n- <example>\n  Context: The user has an approved plan and wants to execute it.\n  user: \"Let's execute the board meeting prep plan\"\n  assistant: \"I'll work through the plan systematically - drafting each deliverable, validating as I go, and flagging anything that needs your input.\"\n  <commentary>\n  Execution should be systematic, following the plan while adapting to what emerges.\n  </commentary>\n  </example>\n- <example>\n  Context: The user wants to draft a communication based on a plan.\n  user: \"Go ahead and draft that email we planned\"\n  assistant: \"I'll draft using the executive-writer approach, incorporating all the context and stakeholder considerations from our plan.\"\n  <commentary>\n  Work phase leverages all the planning context to produce high-quality output efficiently.\n  </commentary>\n  </example>"
-model: inherit
+name: work
+description: "Execute a knowledge work plan efficiently while maintaining quality. Use after the research phase to systematically work through a plan using the right agents for each step. Triggers on requests like 'execute the plan', 'draft that email we planned', 'go ahead and write', or when moving from planning to execution."
+disable-model-invocation: true
 ---
 
-# Camp Work: Knowledge Work Execution Workflow
+# Work: Knowledge Work Execution Workflow
 
 You are orchestrating the **Work phase** of the Compound Knowledge Work loop. Your job is to execute the plan systematically, producing high-quality output while staying adaptable.
 
@@ -81,7 +81,7 @@ Present the completed work to the user with:
 
 ### Right Level of Polish
 - Match polish to the audience and purpose
-- Internal draft ≠ board presentation
+- Internal draft != board presentation
 - Don't over-polish low-stakes work
 
 ## Work Patterns by Type


### PR DESCRIPTION
## Summary

Converts CoworkPowers from a standalone workflow collection to a proper Claude Code plugin. Workflows now use the correct `skills/` directory structure with `SKILL.md` files and updated YAML frontmatter for Claude Code compatibility.

## Changes

- Moves workflows to `skills/` directories with `SKILL.md` format
- Updates plugin manifest to remove invalid `workflows` field
- Simplifies documentation with corrected skill names and installation instructions
- Adds user-specific context to .gitignore

## Testing

Plugin loads successfully with `/coworkpowers:research`, `/coworkpowers:work`, `/coworkpowers:review`, and `/coworkpowers:compound` skills. All 24 agents properly discovered and available.