### PR TITLE
Add marketplace.json for plugin installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "coworkpowers",
+  "owner": {
+    "name": "Nabeel Hyatt"
+  },
+  "metadata": {
+    "description": "Knowledge work superpowers that compound over time"
+  },
+  "plugins": [
+    {
+      "name": "coworkpowers",
+      "source": ".",
+      "description": "Knowledge work superpowers that compound over time. Research, execute, review, and capture learnings to make each task easier than the last.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Nabeel Hyatt"
+      },
+      "homepage": "https://github.com/nabeelhyatt/coworkpowers",
+      "license": "MIT",
+      "category": "productivity",
+      "tags": ["knowledge-work", "productivity", "compound-learning", "decision-making"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` so the repo works as a self-hosted plugin marketplace
- Users can now install with two commands inside Claude Code:
  ```
  /plugin marketplace add nabeelhyatt/coworkpowers
  /plugin install coworkpowers@coworkpowers
  ```

## Test plan

- [ ] Run `/plugin marketplace add nabeelhyatt/coworkpowers` in Claude Code
- [ ] Run `/plugin install coworkpowers@coworkpowers`
- [ ] Verify `/coworkpowers:research` skill is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)