### PR TITLE
Fix marketplace source path validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "coworkpowers",
-      "source": ".",
+      "source": "./",
       "description": "Knowledge work superpowers that compound over time. Research, execute, review, and capture learnings to make each task easier than the last.",
       "version": "1.0.0",
       "author": {


### PR DESCRIPTION
## Summary
- Fixes the `plugins.0.source: Invalid input` error when running `/plugin marketplace add nabeelhyatt/coworkpowers`
- Changes `"source": "."` to `"source": "./"` -- the relative path validator requires the `./` prefix
- PR #3 merged the original broken format; the fix commit was pushed after the squash merge

## Test plan
- [ ] Run `/plugin marketplace add nabeelhyatt/coworkpowers` -- should succeed without schema error
- [ ] Run `/plugin install coworkpowers@coworkpowers` -- should install the plugin
- [ ] Verify skills work: `/coworkpowers:research`, `/coworkpowers:work`, `/coworkpowers:review`, `/coworkpowers:compound`

Generated with [Claude Code](https://claude.com/claude-code)