### PR TITLE
docs: Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,25 +53,44 @@ Next time you do similar work, the Research phase searches these learnings befor
 
 **The practical effect**: your first partner update might take the full Research > Work > Review cycle. Your fourth one loads the template, applies your preferred tone, and skips the research it already has. Faster, cheaper, and more consistent.
 
-## Installation - There are a few ways you can get this up and running in Claude
+## Installation
 
-### 1. Claude Code
+> **Note:** This plugin is currently in development. Marketplace installation is not yet available.
+
+### Claude Code (Local Testing)
+
+The plugin currently requires local installation using the `--plugin-dir` flag:
 
 ```bash
-# Option A: (Easiest) Open Claude Code, then install from Marketplace just copy and paste this line into Claude Code and hit yes, then restart Claude Code after install and start with the first command - /workflow-research and the first task
-/plugin install coworkpowers@coworkpowers
-
-# Option B: Test locally
+# Clone the repository
 git clone https://github.com/nabeelhyatt/coworkpowers.git
+
+# Launch Claude Code with the plugin
 claude --plugin-dir ./coworkpowers
 ```
 
-### Cowork (Claude Desktop) - This is beta. Using the new Claude Cowork you can try this as a plug-in
+After launching, the workflow skills will be available:
+- `/coworkpowers:workflow-research`
+- `/coworkpowers:workflow-work`
+- `/coworkpowers:workflow-review`
+- `/coworkpowers:workflow-compound`
+
+### Cowork (Claude Desktop) - Beta
 
 1. Download [coworkpowers.zip](coworkpowers.zip) from this repository
-2. In Cowork, clikc Plugins in the left sidebar > + to add plug-in > Upload Plugin
+2. In Cowork, click Plugins in the left sidebar → + to add plugin → Upload Plugin
 3. Drag and drop the zip file and hit upload
-4. Go back to cowork and type /workflow-research [task you want done] to get started
+4. Type `/workflow-research [task you want done]` to get started
+
+### Marketplace Installation (Coming Soon)
+
+We're working on making this plugin available via the Claude Code marketplace. Once available, installation will be as simple as:
+
+```bash
+/plugin install coworkpowers@coworkpowers
+```
+
+Track progress on marketplace integration in [Issue #8](https://github.com/nabeelhyatt/coworkpowers/issues/8).
 
 ### Connectors (Optional)
 


### PR DESCRIPTION
## Problem

The README installation instructions claim users can install via marketplace:
```bash
/plugin install coworkpowers@coworkpowers
```

However, this doesn't work because the `coworkpowers` marketplace doesn't exist in Claude Code's known marketplaces, causing the installation to fail with:
```
✘ Failed to install plugin "coworkpowers@coworkpowers": Plugin "coworkpowers" not found in marketplace "coworkpowers"
```

Related: #8

## Changes

This PR updates the installation section to:
- ✅ Add a clear note that marketplace installation is not yet available
- ✅ Document the working local installation method using `--plugin-dir`
- ✅ Add "Coming Soon" section for marketplace installation
- ✅ Fix typo: "clikc" → "click"
- ✅ Reference Issue #8 for tracking marketplace integration progress

## Result

Users will now have accurate installation instructions that work, reducing confusion and failed installation attempts.

### Before
```bash
# Option A: (Easiest) Open Claude Code, then install from Marketplace...
/plugin install coworkpowers@coworkpowers  # ❌ Doesn't work
```

### After
```bash
> **Note:** This plugin is currently in development. Marketplace installation is not yet available.

### Claude Code (Local Testing)
git clone https://github.com/nabeelhyatt/coworkpowers.git
claude --plugin-dir ./coworkpowers  # ✅ Works
```

## Testing

Verified that:
- The markdown renders correctly
- Links work properly
- Instructions are clear and accurate

---

Happy to make any adjustments if you'd prefer different wording or structure!